### PR TITLE
navigation flow update: fixes

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -11,6 +11,6 @@ savespath = C:\Users\strip\Documents\github\STAT\statassets\saves
 templatefilepath = C:\Users\strip\\Documents\github\STAT\statassets\templates
 
 [Toggles]
-showwelcome = True
+showwelcome = False
 showexplanations = True
 

--- a/elements/menu.py
+++ b/elements/menu.py
@@ -7,38 +7,14 @@ def menu() -> None:
 
     # Determine the target for "View Game File"
     def get_view_game_target():
-        if selected_game:
-            return f"/viewgame/{selected_game['name']}" 
-        # ui.notify("Error: No game currently selected!",
-        #          position='top',
-        #          type='warning')
+        return f"/viewgame/"
     
     # Determine the target for "View Game File"
     def get_view_dashboard_target():
-        if selected_game:
-            if selected_save:
-                return f"/loadeddash"
-            # if no selected save
-            else:
-                with ui.dialog() as no_save:
-                    ui.label("You must have a game and a save selected in order to view the dashboard!").classes('break-all')
-                    ui.label("Redirecting to the page to select a save.").classes
-                    ui.button('Close', on_click=no_save.close())
-                return f"viewsaves/{selected_game['name']}"
-        # if no selected_game
-        else:
-            with ui.dialog() as no_game:
-                    ui.label("You've got no game! You must have a game AND a save selected to view the dashboard.").classes('break-all')
-                    ui.label("Redirecting to the page to select a game.")
-                    ui.button('Close', on_click=no_game.close())
-            return f"selectgames" 
-
+        return f"/loadeddash"
+        
     def view_saves():
-        if selected_game:
-            return f"/viewsaves/{selected_game['name']}"
-        # ui.notify("Error: No game currently selected!",
-        #          position='top',
-        #          type='warning')
+        return f"/selectsaves/"
 
     # TODO: deal with no selected_game
     def get_view_save_target():
@@ -60,13 +36,14 @@ def menu() -> None:
                     ui.button('Close', on_click=no_game.close())
             return ''
 
+    # MAIN MENU
     with ui.button(icon='menu').classes('scale-75').props('color="secondary"'):
         with ui.menu() as general_menu:
             with ui.link(target='/'):
                 ui.menu_item('Home')
             ui.separator()
 
-            # Games
+            # GAMES
             with ui.menu_item('Game Menu', auto_close=False):
                 with ui.item_section().props('side'):
                     ui.icon('keyboard_arrow_right')
@@ -81,7 +58,7 @@ def menu() -> None:
                     with ui.link(target='/editgame'):
                         ui.menu_item('Edit Current Game')
 
-            # Saves
+            # SAVES
             with ui.menu_item('Save Menu', auto_close=False):
                 with ui.item_section().props('side'):
                     ui.icon('keyboard_arrow_right')
@@ -98,7 +75,7 @@ def menu() -> None:
                     #    ui.menu_item('Load Save')
                     ui.menu_item('Edit Save')
 
-            # Dashboard
+            # DASHBOARD
             with ui.menu_item('Dashboard', auto_close=False):
                 with ui.item_section().props('side'):
                     ui.icon('keyboard_arrow_right')
@@ -107,7 +84,7 @@ def menu() -> None:
                         ui.menu_item('View Dashboard')
                     ui.menu_item('Save Session', lambda: ui.notify('This will call the Save_Session function in the future.'))
             
-            # Assets
+            # ASSETS
             with ui.menu_item('Assets Menu', auto_close=False):
                 with ui.item_section().props('side'):
                     ui.icon('keyboard_arrow_right')
@@ -118,7 +95,7 @@ def menu() -> None:
                     with ui.link(target='/editasset'):
                         ui.menu_item('Edit Asset')
                         
-            # Effects
+            # EFFECTS
             with ui.menu_item('Effects Menu', auto_close=False):
                 with ui.item_section().props('side'):
                     ui.icon('keyboard_arrow_right')

--- a/pages/create_asset.py
+++ b/pages/create_asset.py
@@ -172,7 +172,7 @@ async def new_asset():
                     ui.icon('warning').classes('text-3xl')
                     ui.label('Warning: No selected game detected.').classes('text-2xl')
                 ui.label('Cannot create asset with no game selected.')
-                ui.label('Please select a game from \'Select Games\'.')
+                ui.label('Please select a game from \'View Games\'.')
                 with ui.link(target = '/selectgames'):
                     ui.button('Find Game File')
             else:

--- a/pages/create_save.py
+++ b/pages/create_save.py
@@ -120,50 +120,59 @@ def create_save():
         with ui.column().classes("flex content-center w-100"):
         # Name of the Save
             with ui.column().classes('justify-center items-center w-full mt-4'):
-                ui.label("All we need from you is the name of the save and a description. ").classes('h-5')
-                ui.label("We'll handle the rest!")
-                with ui.column().classes('items-start'):
-                    name_input = ui.input(label='Save Name: ', placeholder='50 character limit',
-                                    on_change=lambda e: name_chars_left.set_text(str(len(e.value)) + ' of 50 characters used.'))
-                    # allows user to clear the field
-                    name_input.props('clearable')
-                    name_input.bind_value(new_save_dict, 'name')
-                    # This handles the validation of the field.
-                    name_input.validation={"Too short!": enable.is_too_short} 
-                    # Displays the characters.        
-                    name_chars_left = ui.label()
-            
-                # Description of Save    
-                with ui.row().classes('justify-center items-center w-full mt-4'):
-                    with ui.column():
-                        description = ui.input(label='Save Description', placeholder='500 character limit',
-                                        on_change=lambda f: desc_chars_left.set_text(str(len(f.value)) + ' of 500 characters used.'))
-                        description.props('clearable')
-                        
-                        description.bind_value(new_save_dict, 'description')
-                        # this handles the validation of the field.
-                        description.validation={"Too long!": lambda b: enable.is_too_long_variable(b, 500)}
-                        with ui.row():
-                            desc_chars_left = ui.label()
-
-                # Handle the rest behind the scenes
-
-            # Submit button.
-            with ui.row().classes('justify-center items-center w-full mt-4'):
-                # The button submits the dialog providing the text entered
-                submit = ui.button(
-                    "Create Save",
-                    icon='create',
-                    on_click=handle_create_save,
-                )
-                # This enables or disables the button depending on if the input field has errors or not
-                submit.bind_enabled_from(
-                    name_input, "error", backward=lambda x: not x and name_input.value
-                )
-
-                # Disable the button by default until validation is done.
-                submit.disable()
+                if not selected_game or 'name' not in selected_game:
+                    with ui.row():
+                        ui.icon('warning').classes('text-3xl')
+                        ui.label('Warning: No selected game detected.').classes('text-2xl')
+                    ui.label('Cannot create a save file with no game selected.')
+                    ui.label('Please select a game from \'Select Games\' first.')
+                    with ui.link(target = '/selectgames'):
+                        ui.button('Find Game File')
+                else:
+                    ui.label("All we need from you is the name of the save and a description. ").classes('h-5')
+                    ui.label("We'll handle the rest!")
+                    with ui.column().classes('items-start'):
+                        name_input = ui.input(label='Save Name: ', placeholder='50 character limit',
+                                        on_change=lambda e: name_chars_left.set_text(str(len(e.value)) + ' of 50 characters used.'))
+                        # allows user to clear the field
+                        name_input.props('clearable')
+                        name_input.bind_value(new_save_dict, 'name')
+                        # This handles the validation of the field.
+                        name_input.validation={"Too short!": enable.is_too_short} 
+                        # Displays the characters.        
+                        name_chars_left = ui.label()
                 
+                    # Description of Save    
+                    with ui.row().classes('justify-center items-center w-full mt-4'):
+                        with ui.column():
+                            description = ui.input(label='Save Description', placeholder='500 character limit',
+                                            on_change=lambda f: desc_chars_left.set_text(str(len(f.value)) + ' of 500 characters used.'))
+                            description.props('clearable')
+                            
+                            description.bind_value(new_save_dict, 'description')
+                            # this handles the validation of the field.
+                            description.validation={"Too long!": lambda b: enable.is_too_long_variable(b, 500)}
+                            with ui.row():
+                                desc_chars_left = ui.label()
+
+                    # Handle the rest behind the scenes
+
+                    # Submit button.
+                    with ui.row().classes('justify-center items-center w-full mt-4'):
+                        # The button submits the dialog providing the text entered
+                        submit = ui.button(
+                            "Create Save",
+                            icon='create',
+                            on_click=handle_create_save,
+                        )
+                        # This enables or disables the button depending on if the input field has errors or not
+                        submit.bind_enabled_from(
+                            name_input, "error", backward=lambda x: not x and name_input.value
+                        )
+
+                        # Disable the button by default until validation is done.
+                        submit.disable()
+                        
 
 
-        
+            

--- a/pages/edit_asset.py
+++ b/pages/edit_asset.py
@@ -23,73 +23,93 @@ async def content() -> None:
         file_path = ''
 
         asset_schema = {
-                    "name":{
-                        'type': 'string', 
-                    },
-                    "category":{
-                        'type': 'string', 
-                    },
-                    "description":{
-                        'type': 'string', 
-                    },
-                    "source":{
-                        'type': 'string', 
-                    },
-                    "asset_type":{
-                        'type': 'string', 
-                    },
-                    "attributes":{
-                        'type': 'array'
-                        },
-                    "buy_costs":{
-                        'type': 'object',
-                    },
-                    "sell_prices":{
-                        'type': 'object', 
-                    },
-                    "special":{
-                        'type': 'string', 
-                    },
-                    "effects":{
-                        'type': 'array', 
-                    },
-                    "other":{
-                        'type': 'string', 
-                    },
-                    "icon":{
-                        'type': 'string', 
-                    },
-                    "image":{
-                        'type': 'string', 
-                    },
-                } 
+            "name":{
+                'type': 'string', 
+            },
+            "category":{
+                'type': 'string', 
+            },
+            "description":{
+                'type': 'string', 
+            },
+            "source":{
+                'type': 'string', 
+            },
+            "asset_type":{
+                'type': 'string', 
+            },
+            "attributes":{
+                'type': 'array'
+                },
+            "buy_costs":{
+                'type': 'object',
+            },
+            "sell_prices":{
+                'type': 'object', 
+            },
+            "special":{
+                'type': 'string', 
+            },
+            "effects":{
+                'type': 'array', 
+            },
+            "other":{
+                'type': 'string', 
+            },
+            "icon":{
+                'type': 'string', 
+            },
+            "image":{
+                'type': 'string', 
+            },
+        } 
 
-        try:
-            selected_name = selected_asset['name'].lower()
-            name_result = format_str_for_filename_super(selected_name)
-            asset_default_names = multi_json_names_getter(selected_game['asset_default_path'], 'assets')
-            asset_custom_names = multi_json_names_getter(selected_save['asset_customs_path'], 'assets')
-
-            if selected_name in asset_default_names:
-                file_path = selected_game['asset_default_path']
-            elif selected_name in asset_custom_names:
-                file_path = selected_save['asset_customs_path']
-
-        except:
-            ui.notify("Error: Issue with formatting the name result!",
-                        position='top',
-                        type='warning')
-            
-        if name_result['result']:
-            asset_json = single_asset_fetch(file_path,name_result['string'])
-            try:
-                ui.json_editor({'content': {'json': asset_json['asset']}},
-                               on_change=lambda e: ui.notify(f'Change: {e}'))
-            except:
-                ui.notify("Error: Problem loading the json into the json editor.")
+        # If no selected_game
+        if not selected_game or 'name' not in selected_game:
+            with ui.row():
+                ui.icon('warning').classes('text-3xl')
+                ui.label('Warning: No selected game detected.').classes('text-2xl')
+            ui.label('Cannot edit an asset with no game selected.')
+            ui.label('Please select a game from \'Select Games\'.')
+            ui.label('And be sure to select an asset too.')
+            with ui.link(target = '/selectgames'):
+                ui.button('Find Game File')
+        # If no selected_asset
+        elif not selected_asset or 'name' not in selected_asset:
+            with ui.row():
+                ui.icon('warning').classes('text-3xl')
+                ui.label('Warning: No selected asset detected.').classes('text-2xl')
+            ui.label('Cannot edit an asset with no asset selected.')
+            ui.label('Please select an asset from \'Select Assets\'.')
+            with ui.link(target = '/selectassets'):
+                ui.button('Find Asset File')
         else:
-            ui.label("Error: Problem converting the asset's name to a file name.")
-           
+            try:
+                selected_name = selected_asset['name'].lower()
+                name_result = format_str_for_filename_super(selected_name)
+                asset_default_names = multi_json_names_getter(selected_game['asset_default_path'], 'assets')
+                asset_custom_names = multi_json_names_getter(selected_save['asset_customs_path'], 'assets')
+
+                if selected_name in asset_default_names:
+                    file_path = selected_game['asset_default_path']
+                elif selected_name in asset_custom_names:
+                    file_path = selected_save['asset_customs_path']
+
+            except:
+                ui.notify("Error: Issue with formatting the name result!",
+                            position='top',
+                            type='warning')
+                
+            if name_result['result']:
+                asset_json = single_asset_fetch(file_path,name_result['string'])
+                try:
+                    ui.json_editor({'content': {'json': asset_json['asset']}},
+                                on_change=lambda e: ui.notify(f'Change: {e}'))
+                except:
+                    ui.notify("Error: Problem loading the json into the json editor.")
+            else:
+                ui.label("Error: Problem converting the asset's name to a file name.")
+            
 # gets the assets as a dictionary
 async def assets_to_dictionary(assets: list, assets_as_dict: dict) -> dict:
     for asset in assets:

--- a/pages/edit_game.py
+++ b/pages/edit_game.py
@@ -9,15 +9,14 @@ enable = Enable()
 async def edit_game():
     with theme.frame('Edit Game'):
         selected_game = app.storage.user.get("selected_game", {})
-        print(selected_game['name'])
 
-        with ui.column().classes("flex content-center w-100"):
+        with ui.column().classes("flex content-center"):
             # If no selected_game, open up prompt to select one
             if not selected_game or 'name' not in selected_game:
                 with ui.row():
                     ui.icon('warning').classes('text-3xl')
                     ui.label('Warning: No selected game detected.').classes('text-2xl')
-                ui.label('Cannot create asset with no game selected.')
+                ui.label('Cannot edit a game with no game selected.')
                 ui.label('Please select a game from \'Select Games\'.')
                 with ui.link(target = '/selectgames'):
                     ui.button('Find Game File')
@@ -84,4 +83,4 @@ async def edit_game():
                             edit_actors.bind_visibility(has_actors_switch, 'value')
 
 
-        ui.button('Print Game', on_click=lambda: ui.notify(selected_game, type='positive', position='top'))
+                ui.button('Print Game', on_click=lambda: ui.notify(selected_game, type='positive', position='top'))

--- a/pages/game_detail.py
+++ b/pages/game_detail.py
@@ -5,7 +5,7 @@ from classes.Enable import *
 
 enable = Enable()
 
-@ui.page('/viewgame/{game_name}')
+@ui.page('/viewgame/')
 async def content() -> None:
     with theme.frame(f'Game Details'):
         edited_game = {}
@@ -29,14 +29,15 @@ async def content() -> None:
                 with ui.link(target='/createeffect'):
                     btn_create_event = ui.button('Create Effect')
                     btn_create_event.bind_enabled_from(bool(selected_game))
-
-            # If no game is selected, prompt the user to select one
+                
+            # No game selected
             if not selected_game or 'name' not in selected_game:
                 with ui.row():
                     ui.icon('warning').classes('text-3xl')
                     ui.label('Warning: No selected game detected.').classes('text-2xl')
-                ui.label('Cannot create asset with no game selected.')
-                ui.label('Please select a game from \'Select Games\'.')
+                ui.label('Cannot view the details for a game with no game selected.')
+                ui.label('Please select a game from \'View Games\'.')
+                ui.label('Then return here to view the save files.')
                 with ui.link(target = '/selectgames'):
                     ui.button('Find Game File')
             else:

--- a/pages/loaded_save_dashboard.py
+++ b/pages/loaded_save_dashboard.py
@@ -25,8 +25,27 @@ async def dashboard():
         saves_paths = selected_game.get("save_files_path", "Not Set")
         turn_type = ""
 
-        # if the dictionaries are not empty
-        if bool(selected_save) and bool(selected_game):
+        # No game or save selected
+        if not selected_game or 'name' not in selected_game:
+            with ui.row():
+                ui.icon('warning').classes('text-3xl')
+                ui.label('Warning: No selected game detected.').classes('text-2xl')
+            ui.label('Cannot view a save file for a game with no game or save selected.')
+            ui.label('Please select a game from \'View Games\'.')
+            ui.label('Then select a save from \'View Saves\'.')
+            with ui.link(target = '/selectgames'):
+                ui.button('Find Game File')
+        elif not selected_save or 'name' not in selected_save:
+            with ui.row():
+                ui.icon('warning').classes('text-3xl')
+                ui.label('Warning: No selected save detected.').classes('text-2xl')
+            ui.label('Cannot view a save file for a game with no  save selected.')
+            ui.label('Please select a game from \'View Saves\'.')
+            with ui.link(target = '/selectsaves'):
+                ui.button('Find Save File')
+            
+
+        else:
             # Everything has loaded properly, go for it!
             counters = selected_save['counters']
 
@@ -130,14 +149,7 @@ async def dashboard():
                                     for asset in sorted_assets[category]:
                                         await render_asset_cards(asset)
                         ui.separator()
-
-        else:
-            games = []
-            games = get_games_names(game_paths)
-            # Didn't load properly from app.storage.user
-            # Ask user to pick files to load.
-            ui.label("Error loading from selected game! Please pick games from below.").classes('w-40')
-            ui.select(options=games, with_input=True, on_change=lambda e: select_game(game_paths, e.value))
+        
             
 # Render the counters.
 @ui.refreshable

--- a/pages/select_games.py
+++ b/pages/select_games.py
@@ -23,14 +23,14 @@ async def select_games():
             app.storage.user["existing_games"] = existing_games
 
         ui.label("Select a game to use it as the basis for creating an asset, save, or effect.").classes('text-xl')
-        ui.label("Please note that selecting a game will your currently selected save and you will lose your changes.")
-        ui.label("Make sure you save your data before doing this!")
+        ui.label("Please note that selecting a game will unload your currently selected save and you will lose your changes.")
+        ui.label("Make sure to save your data before doing this!")
 
         # Buttons!!!
         with ui.row():
-            btn_detail = ui.button('View Detail', on_click=lambda: game_view_details(selected_game['name']))
+            btn_detail = ui.button('View Detail', on_click=lambda: game_view_details(selected_game))
             btn_detail.bind_enabled_from(bool(app.storage.user["existing_games"]))
-            btn_saves = ui.button('View Saves', on_click=lambda: view_game_saves({game['name']}))
+            btn_saves = ui.button('View Saves', on_click=lambda: view_game_saves(selected_game))
             btn_saves.bind_enabled_from(bool(app.storage.user["existing_games"]))
         # Displaying the games.
         game_card_container = ui.row().classes("grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4")
@@ -39,19 +39,21 @@ async def select_games():
                 await render_game_cards(existing_games, game)
 
 # Select a game to load into app.storage.user
-def view_game_saves(selected_game_name: str):
-    for name in selected_game_name:
-        # getting the name to be correct.
-        file_name = format_str_for_filename_super(name)['string']
+def view_game_saves(selected_game):
+    if not selected_game or 'name' not in selected_game:
+        ui.notify("Please select a game before trying to view it's saves.",
+                  position='top',
+                  type='warning')
+    else:
+        ui.navigate.to(f"/selectsaves/")
 
-        ui.navigate.to(f"/selectsaves/{file_name}")
-
-def game_view_details(selected_game_name: str):
-    for name in selected_game_name:
-        # getting the name to be correct.
-        file_name = format_str_for_filename_super(name)['string']
-
-        ui.navigate.to(f"/viewgame/{name}")
+def game_view_details(selected_game):
+    if not selected_game or 'name' not in selected_game:
+        ui.notify("Please select a game before trying to view it's details.",
+                  position='top',
+                  type='warning')
+    else:
+        ui.navigate.to(f"/viewgame/")
 
 def select_target_game(existing_games: dict, selected_game_name: str):
     for name in selected_game_name:

--- a/pages/select_saves.py
+++ b/pages/select_saves.py
@@ -5,33 +5,44 @@ from nicegui import app, ui
 from handlers.savehandler import *
 
 # call the function to pull in that info of the saves.
-@ui.page('/selectsaves/{game_name}')
+@ui.page('/selectsaves/')
 async def view_saves():
     with theme.frame('View Saves'):
         # File path for save data
         selected_game = app.storage.user.get("selected_game", {})
         saves_paths = selected_game.get("save_files_path", "Not Set")
-        
         existing_saves = {}
-        # getting the existing saves for the loaded game
-        try:
-            existing_saves = get_saves(saves_paths)
-        except Exception as e:
-            ui.notify(f"Error loading saves: {str(e)}", type='negative', position="top",)
-            return
-        
-        with ui.link(target='/createsave'):
-            ui.button("Create New Save")
 
-        ui.label("Select a save to load:").classes('h-4')
-    
-        save_card_container = ui.row().classes("full flex items-center")
-        with save_card_container:
-            if existing_saves:
-                for save in existing_saves.values():
-                    await render_save_cards(existing_saves, save)
-            else:
-                ui.label("No saves to display!")
+        # No game selected
+        if not selected_game or 'name' not in selected_game:
+            with ui.row():
+                ui.icon('warning').classes('text-3xl')
+                ui.label('Warning: No selected game detected.').classes('text-2xl')
+            ui.label('Cannot view the saves for a game with no game selected.')
+            ui.label('Please select a game from \'View Games\'.')
+            ui.label('Then return here to view the save files.')
+            with ui.link(target = '/selectgames'):
+                ui.button('Find Game File')
+        else:
+            # getting the existing saves for the loaded game
+            try:
+                existing_saves = get_saves(saves_paths)
+            except Exception as e:
+                ui.notify(f"Error loading saves: {str(e)}", type='negative', position="top",)
+                return
+            
+            with ui.link(target='/createsave'):
+                ui.button("Create New Save")
+
+            ui.label("Select a save to load:").classes('h-4')
+        
+            save_card_container = ui.row().classes("full flex items-center")
+            with save_card_container:
+                if existing_saves:
+                    for save in existing_saves.values():
+                        await render_save_cards(existing_saves, save)
+                else:
+                    ui.label("No saves to display!")
 
 def load_save(existing_saves, selected_save_name):
     for name in selected_save_name:


### PR DESCRIPTION
Altered menu.py and various pages to avoid crashing if trying to view a page that needs a selected_game, selected_save, or selected_asset without any of those things set. Accomplished smooth, consistent handling by doing the handling on the individual pages themselves.
 - Mostly I copy+pasted a block of code to inform users of what was missing and direct them to the page where they could load the appropriate resource.
 - Future room for improvement: rewrite this into a reusable renderable UI element (MissingObjectAlert maybe) to cut down on repeated code.

elements\menu.py
- ended dynamic routing through the navigation here.
 - Will revisit implementing this if I can figure out how to get the dang notifies to not fire on menu.py's loading when tied to a link.

pages\create_asset.py
 - Adjusted wording. Alerts to needing a game selected.

pages\create_save.py
 - Implemented handling for no game selected.

pages\edit_asset.py
 - fixed some formatting with asset_schema and disabled prettier extension
 - added handling for no game selected and no asset selected.

pages\edit_game.py
 - changed wording in a label, removed a print
 - moved 'Print Game' button to only show when assets are there
 - TODO: fix  message aligned left

pages\game_detail.py
 - Changed page to no longer require a game_name as part of the path
 - added better wording for 'no game selected'

pages\loaded_save_dashboard.py
 - removed attempt to check selected_save and selected_game like bools
 - added in handling for no selected_game and no selected_save

pages\select_games.py
 - adjusted buttons to no longer pass game[name] as part of route
 - adjusted buttons to properly notify user when they need to select a game to navigate with the button

pages\select_saves.py
 - moved the logic for 'no selected_game' to top of page for easier reading and consistency with other pages