### PR TITLE
Fixing issue with select_saves

### DIFF
--- a/handlers/savehandler.py
+++ b/handlers/savehandler.py
@@ -13,20 +13,29 @@ def get_saves(saves_directory_path: str) -> dict:
     save_names = []
     save_names = get_save_names(saves_directory_path)
     full_save_path = ''
-    
+    get_save_result = {}
     save_files = {}
+
     for save in save_names:
         save_name = save.lower()
-        full_save_path = saves_directory_path + '\\' + save_name + '\\' + save_name + ".json"
-        save_files[save_name] = single_json_getter_fullpath(full_save_path, 'save')
-    
-    return save_files
+        full_save_path = Path(saves_directory_path + '\\' + save_name + '\\' + save_name + ".json")
+        get_save_result = single_json_getter_fullpath(full_save_path, 'save')
+
+        ## checking the saves
+        if get_save_result['result']:
+            save_files[save] = get_save_result['json']
+        else:
+            get_save_result['message'] = "Failed! Could not retrieve the saves."
+
+    if save_files:
+        return save_files
+    else:
+        return {}
 
 # for creating a new save from the gui
 def new_save_gui(configfilename: str, game_name: str, new_save_dict: dict) -> dict:
     write_result = {'result': False, 'string': '', 'dict': {}, 'debug': []}
     create_result = {'result': False, 'message': '', 'dict':{}}
-
     try:
         # Format game name
         game_name_result = format_str_for_filename_super(game_name)
@@ -103,8 +112,10 @@ def new_save_gui(configfilename: str, game_name: str, new_save_dict: dict) -> di
 
     return create_result
 
+# RThe list of names.
 def get_save_names(directory_path: str) -> list:
     save_names = []
+    save_names_result = {'result': False, 'message':"", 'list': []}
     save_names_result = multi_file_names_getter(directory_path, "saves")
     if save_names_result['result']:
         save_names = save_names_result['list']
@@ -112,6 +123,7 @@ def get_save_names(directory_path: str) -> list:
         print("Error! Problem with fetching save names.")
     return save_names
 
+# Convert the save name into a file friendly format.
 def convert_save_name(saveName: str) -> str:
     formatted_name = ""
     try:
@@ -119,8 +131,7 @@ def convert_save_name(saveName: str) -> str:
         formatted_name = formatted_name.lower()
         formatted_name = formatted_name.replace(" ", "_")
     except Exception:
-            tb = sys.exception().__traceback__
-            print(tb)
+            print(traceback.format_exc())
     return formatted_name
 
 # return a result dictionary from getting a single json file
@@ -134,6 +145,7 @@ def load_save(full_save_path: str) -> dict:
         print("Error with returning save!")
         return {}
 
+# Checks the save dict's keys against the keys of the save template.
 def check_template_bool(save: dict, template_path: str) -> bool:
     error_message = ''
     result = False
@@ -145,6 +157,7 @@ def check_template_bool(save: dict, template_path: str) -> bool:
         print(traceback.format_exc())
         return result
 
+# Returne a dictionary of {"name": "", "file":""} of formatted save name
 def get_new_save_name(directory_path: str, name: str, ) -> dict:
     file_name = ""
     saves = []

--- a/helpers/utilities.py
+++ b/helpers/utilities.py
@@ -38,7 +38,7 @@ def format_str_for_filename(string: str) -> str:
 # Returns a result dictionary    
 def format_str_for_filename_super(string: str) -> dict:
     # TODO: Upgrade this to use regex to strip unwanted characters.
-    result_dict = {'result':False, 'string':""}
+    result_dict = {'result': False, 'string':""}
     error_message = ""
     formatted_string = ""
     try:

--- a/pages/create_asset.py
+++ b/pages/create_asset.py
@@ -224,7 +224,7 @@ async def new_asset():
                       multi_line=True)
 
         except Exception as e:
-            print(e)
+            print(traceback.format_exc())
             ui.notify("""Error: Could not save. An unexpected error has occured. Please check application logs for more information.""",
                       position='top',
                       type='negative',

--- a/pages/select_saves.py
+++ b/pages/select_saves.py
@@ -1,8 +1,8 @@
 from elements.message import message
 import elements.theme as theme
-from pathlib import PurePath, Path
 from nicegui import app, ui
 from handlers.savehandler import *
+import traceback
 
 # call the function to pull in that info of the saves.
 @ui.page('/selectsaves/')
@@ -18,6 +18,33 @@ async def view_saves():
         games_path = paths.get("gamespath", "Not Set")
         saves_path = paths.get("savespath", "Not Set")
 
+        def load_save_from_storage(existing_saves, selected_save_name):
+            for name in selected_save_name:
+                selected_save = {}
+                save_to_get = convert_save_name(name)
+                try:
+                    selected_save = existing_saves[save_to_get]
+                    app.storage.user['is_save_loaded']  = True
+                except:
+                    ui.notify("Unable to load save.", type='negative', position="top",)
+                finally:
+                    # pass back empty dict even if nothing is available.
+                    app.storage.user["selected_save"] = selected_save
+                    ui.navigate.reload()
+
+        async def render_save_cards(existing_saves, save):
+            with ui.card().tight().style('width: 100%; max-width: 250px; aspect-ratio: 4 / 3; max-height: 175px;'):
+                with ui.card_section():
+                    ui.label().bind_text_from(save, 'name', backward=lambda name: f'{name}')
+                    ui.label().bind_text_from(save, 'base_game',
+                                                            backward=lambda base: f'Base Game: {base}')
+                    ui.label().bind_text_from(save, 'create_date',
+                                                            backward=lambda create: f'Start Date: {create}')
+                    ui.label().bind_text_from(save, 'date_last_save',
+                                                            backward=lambda last_save: f'Last Save: {last_save}')
+                    with ui.card_actions().classes("w-full justify-end"):
+                        ui.button('Select Save', on_click=lambda: load_save_from_storage(existing_saves, {save['name']}))
+
         # No game selected
         if not selected_game or 'name' not in selected_game:
             with ui.row():
@@ -30,64 +57,56 @@ async def view_saves():
                 ui.button('Find Game File')
         # There IS a selected_game
         else:
-            # Getting the games
-            str_games_path = root_path + games_path
-            # formatting the game name
-            game_format_result = format_str_for_filename_super
-            game_file_name = ''
-            if game_format_result['result']:
-                game_file_name = game_format_result['string']
-            else:
-                ui.notify("Error with formatting selected_game name.", position='top', type='warning')
-
-            
-            str_saves_path = str_games_path + '\\' + game_file_name + '\\' +  saves_path
-            existing_saves = {}
-            # getting the existing saves for the loaded game
             try:
-                existing_saves = get_saves(str_saves_path)
-            except Exception as e:
-                ui.notify(f"Error loading saves: {str(e)}", type='negative', position="top",)
-                return
-            
-            with ui.link(target='/createsave'):
-                ui.button("Create New Save")
-
-            ui.label("Select a save to load:").classes('h-4')
-        
-            save_card_container = ui.row().classes("full flex items-center")
-            with save_card_container:
-                if existing_saves:
-                    for save in existing_saves.values():
-                        await render_save_cards(existing_saves, save)
+                # Getting the games
+                str_games_path = root_path + games_path
+                # formatting the game name
+                game_format_result = format_str_for_filename_super(selected_game['name'])
+                game_file_name = ''
+                if game_format_result['result']:
+                    game_file_name = game_format_result['string']
                 else:
-                    ui.label("No saves to display!")
+                    ui.notify("Error with formatting selected_game name.", position='top', type='warning')
+                
+                str_saves_path = str_games_path + '\\' + game_file_name + '\\' +  saves_path
+                existing_saves = {}
+                # getting the existing saves for the loaded game
+                try:
+                    existing_saves_result = get_saves(str_saves_path)
+                    # If it doesnt' return a result_dict, we know we have the saves.
+                    if existing_saves_result:
+                        existing_saves = existing_saves_result
+                    else:
+                        ui.notify(f"""Error: Could not fetch saves for the game! Please check folder location.""",
+                                  position='top',
+                                  type='warning',
+                                  multi_line=True)
+                except Exception as e:
+                    print(traceback.format_exc())
+                    ui.notify(f"Error loading saves: {str(e)}", type='negative', position="top",)
+                    return
+                
+                with ui.link(target='/createsave'):
+                    ui.button("Create New Save")
 
-def load_save_from_storage(existing_saves, selected_save_name):
-    for name in selected_save_name:
-        selected_save = {}
-        save_to_get = convert_save_name(name)
-        try:
-            selected_save = existing_saves[save_to_get]
-            app.storage.user['is_save_loaded']  = True
-        except:
-            ui.notify("Unable to load save.", type='negative', position="top",)
-        finally:
-            # pass back empty dict even if nothing is available.
-            app.storage.user["selected_save"] = selected_save
-            ui.notify(f"Success! You selected save {name}.", type='positive', position='top')
-            ui.navigate.reload()
+                ui.label("Select a save to load:").classes('h-4')
+            
+                save_card_container = ui.row().classes("full flex items-center")
+                with save_card_container:
+                    if existing_saves:
+                        for save in existing_saves.values():
+                            await render_save_cards(existing_saves, save)
+                    else:
+                        ui.label("No saves to display!")
+            except Exception as e:
+                print(traceback.format_exc())
+                ui.notify(f"""Save files could not be viewed..
+                            Please check in console for traceback.""",
+                            type='negative',
+                            position='top',
+                            multi_line = True)
 
-async def render_save_cards(existing_saves, save):
-    with ui.card().tight().style('width: 100%; max-width: 250px; aspect-ratio: 4 / 3; max-height: 175px;'):
-        with ui.card_section():
-            ui.label().bind_text_from(save, 'name', backward=lambda name: f'{name}')
-            ui.label().bind_text_from(save, 'base_game',
-                                                    backward=lambda base: f'Base Game: {base}')
-            ui.label().bind_text_from(save, 'create_date',
-                                                    backward=lambda create: f'Start Date: {create}')
-            ui.label().bind_text_from(save, 'date_last_save',
-                                                    backward=lambda last_save: f'Last Save: {last_save}')
-            with ui.card_actions().classes("w-full justify-end"):
-                ui.button('Select Save', on_click=lambda: load_save_from_storage(existing_saves, {save['name']}))
+
+
+
 


### PR DESCRIPTION
During file rework I was returning a result_dict instead a of a dict of saves. Frankly I'm shocked I haven't found more of these errors yet.

handlers\savehandler.py
 - fixed get_saves() to return dictionary of saves

helpers\utilitis.py
 - i added a space in a dict in format_str_for_filename_super

pages\create_asset.py
 - changed a print(e) to print the traceback instead!

pages\select_saves.py
 = load_save_from_storage
 - added try except for better error handling in the future.
 - moved to top of file for consistency of layout with other pages. = render_save_cards
 - moved to top of page for consistency of layout with other pages = view_saves
 - troubleshot why it wasn't working
 - added try except for more graceful error handling in the future
 - error was with return from get_saves()
   - was getting a result_dict, was expecting a dict of saves in {'savename':{save_dict}} format.